### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Check out `Example` for an app example.
 
 
 ```objc
-#import <UIApplication+SSAppURLs.h>
+# import <UIApplication+SSAppURLs.h>
 
 // Does the current device have skype installed?
 BOOL deviceSupportsSkype = [[UIApplication sharedApplication] 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
